### PR TITLE
Update CGCFinder.py

### DIFF
--- a/CGCFinder.py
+++ b/CGCFinder.py
@@ -132,6 +132,11 @@ def startSearch(startRow, contig):
 								ID = note.split("=")[1]
 						row = [str(j), fd, str(upDown[1]), str(upDown[0]), 'CGC'+str(num_clusters), contig[j][0], contig[j][3], contig[j][4], ID, contig[j][6], contig[j][8]]
 					else:
+						notes = contig[j][8].split(";")
+						ID= ""
+						for note in notes:
+							if "ID" in note:
+								ID = note.split("=")[1]
 						row = [str(j), 'null', 'null', 'null', 'CGC'+str(num_clusters), contig[j][0], contig[j][3], contig[j][4], ID, contig[j][6]]
 					try:
 						row.append(contig[j][8])


### PR DESCRIPTION
When a gene is annotated as non-signature, its protein ID (column 9 in the final CGCFinder output file) will inherit from the previous entry because the variable "ID" is not redefined (line 135).