### PR TITLE
fix default eCAMI db_type

### DIFF
--- a/dbcan/eCAMI/prediction.py
+++ b/dbcan/eCAMI/prediction.py
@@ -267,7 +267,7 @@ def get_validation_results(input_fasta_file,database_dir,output_dir,output_file_
 class eCAMI_config(object):
     def __init__(
         self,
-        db_type = 'Cazyme',
+        db_type = 'CAZyme',
         output = 'examples/prediction/output/test_pred_cluster_labels.txt',
         input = 'examples/prediction/input/test.faa',
         k_mer = 8,

--- a/dbcan_cli/run_dbcan.py
+++ b/dbcan_cli/run_dbcan.py
@@ -194,6 +194,7 @@ def cli_main():
     if tools[2]:
         print("\n\n***************************3. eCAMI start***************************************************\n\n")
         ecami_config = eCAMI_config(
+            db_type = args.eCAMI_kmer_db,
             input = f"{outPath}uniInput",
             output= f"{outPath}eCAMI.out",
             k_mer = args.eCAMI_k_mer,


### PR DESCRIPTION
Hi, I noticed that the default database for eCAMI was spelled as 'Cazyme' which means it uses the EC database by default (also what is used by the main run_dbcan).  Is this intentional?  The code is looking for 'CAZyme', so I changed it so it will match against the CAZyme domains by default instead.  Thanks!