### PR TITLE
Update run_dbcan.py

### DIFF
--- a/dbcan_cli/run_dbcan.py
+++ b/dbcan_cli/run_dbcan.py
@@ -515,6 +515,9 @@ def cli_main():
     def unique(seq):
         exists = set()
         return [x for x in seq if not (x in exists or exists.add(x))]
+    
+    arr_eCAMI = None
+    arr_hmmer = None
 
     # check if files exist. if so, read files and get the gene numbers
     if tools[0]:


### PR DESCRIPTION
Fixed when there are no hmm and eCAMI results, overview table cannot be created.