### PR TITLE
Add all of the valid CGCFinder options to allow for dbCAN-seq replication

### DIFF
--- a/dbcan_cli/run_dbcan.py
+++ b/dbcan_cli/run_dbcan.py
@@ -693,7 +693,7 @@ def cli_main():
     parser.add_argument('--out_dir', default="output", help='Output directory')
     parser.add_argument('--db_dir', default="db", help='Database directory')
     parser.add_argument('--cgc_dis', default=2, type=int, help='CGCFinder Distance value')
-    parser.add_argument('--cgc_sig_genes', default='tp', choices=['tp', 'tf','all'], help='CGCFinder Signature Genes value')
+    parser.add_argument('--cgc_sig_genes', default='tp', choices=['tf', 'tp', 'stp', 'tp+tf', 'tp+stp', 'tf+stp', 'all'], help='CGCFinder Signature Genes value')
     parser.add_argument('--tools', '-t', nargs='+', choices=['hmmer', 'diamond', 'eCAMI', 'all'], default='all', help='Choose a combination of tools to run')
     parser.add_argument('--use_signalP', default=False, type=bool, help='Use signalP or not, remember, you need to setup signalP tool first. Because of signalP license, Docker version does not have signalP.')
     parser.add_argument('--signalP_path', '-sp',default="signalp", type=str, help='The path for signalp. Default location is signalp')


### PR DESCRIPTION
Hello,

The --cgc_sig_genes command line options are "tp", "tf", and "all". When I ran with the option "all", I expected this to behave with the functionality CAZyme+tp+tf, but I notice that the only CGCs produced also have STPs.

It appears that in the CGCFinder.py script, the "all" parameter is actually treated as CAZyme+tp+tf+stp, but this does not match the command line help tips. See lines 32 - 41 of CGCFinder.py:

``` 
#global vars
cluster = [0, 0, 0, 0] #cazyme, tp, tf, stp
num_clusters = 0


#define boolean function to determine if a cluster meets cluster requirements
def isCluster(siggenes): 
	global cluster
	if siggenes == 'all':
		if cluster[0] > 0 and cluster[1] > 0 and cluster[2] > 0 and cluster[3]:
```

I wanted to annotate my genomes with the same parameters as dbCAN-seq (CAZyme+tp+tf), but that does not seem possible with the current command line options. I suggest adding --cgc_sig_genes command line options for all of the different valid CGCFinder siggenes parameters: ['all', 'tf', 'tp', 'stp', 'tp+tf', 'tp+stp', 'tf+stp'].

All this would require is changing the argparse list of valid inputs, as my pull request adds. At the very least, adding the 'tp+tf' options allows the recreation of the dbCAN-seq functionality.