### PR TITLE
Add hmmsearch option that use hmmsearch instead of hmmscan

### DIFF
--- a/dbcan_cli/hmmscan_parser.py
+++ b/dbcan_cli/hmmscan_parser.py
@@ -29,11 +29,14 @@ import sys
 import os
 
 
-def run(input_file, eval_num=1e-15, coverage=0.35, verbose=False):
+def run(input_file, eval_num=1e-15, coverage=0.35, hmmsearch=False, verbose=False):
 
 	tmpfile = "temp." + str(os.getpid())
 
-	call("cat "+input_file+"  | grep -v '^#' | awk '{print $1,$3,$4,$6,$13,$16,$17,$18,$19}' | sed 's/ /\t/g' | sort -k 3,3 -k 8n -k 9n | perl -e 'while(<>){chomp;@a=split;next if $a[-1]==$a[-2];push(@{$b{$a[2]}},$_);}foreach(sort keys %b){@a=@{$b{$_}};for($i=0;$i<$#a;$i++){@b=split(/\t/,$a[$i]);@c=split(/\t/,$a[$i+1]);$len1=$b[-1]-$b[-2];$len2=$c[-1]-$c[-2];$len3=$b[-1]-$c[-2];if($len3>0 and ($len3/$len1>0.5 or $len3/$len2>0.5)){if($b[4]<$c[4]){splice(@a,$i+1,1);}else{splice(@a,$i,1);}$i=$i-1;}}foreach(@a){print $_.\"\n\";}}' > " + tmpfile, shell=True)
+	if hmmsearch:
+		call("cat "+input_file+"  | grep -v '^#' | awk '{print $4,$6,$1,$3,$13,$16,$17,$18,$19}' | sed 's/ /\t/g' | sort -k 3,3 -k 8n -k 9n | perl -e 'while(<>){chomp;@a=split;next if $a[-1]==$a[-2];push(@{$b{$a[2]}},$_);}foreach(sort keys %b){@a=@{$b{$_}};for($i=0;$i<$#a;$i++){@b=split(/\t/,$a[$i]);@c=split(/\t/,$a[$i+1]);$len1=$b[-1]-$b[-2];$len2=$c[-1]-$c[-2];$len3=$b[-1]-$c[-2];if($len3>0 and ($len3/$len1>0.5 or $len3/$len2>0.5)){if($b[4]<$c[4]){splice(@a,$i+1,1);}else{splice(@a,$i,1);}$i=$i-1;}}foreach(@a){print $_.\"\n\";}}' > " + tmpfile, shell=True)
+	else:
+		call("cat "+input_file+"  | grep -v '^#' | awk '{print $1,$3,$4,$6,$13,$16,$17,$18,$19}' | sed 's/ /\t/g' | sort -k 3,3 -k 8n -k 9n | perl -e 'while(<>){chomp;@a=split;next if $a[-1]==$a[-2];push(@{$b{$a[2]}},$_);}foreach(sort keys %b){@a=@{$b{$_}};for($i=0;$i<$#a;$i++){@b=split(/\t/,$a[$i]);@c=split(/\t/,$a[$i+1]);$len1=$b[-1]-$b[-2];$len2=$c[-1]-$c[-2];$len3=$b[-1]-$c[-2];if($len3>0 and ($len3/$len1>0.5 or $len3/$len2>0.5)){if($b[4]<$c[4]){splice(@a,$i+1,1);}else{splice(@a,$i,1);}$i=$i-1;}}foreach(@a){print $_.\"\n\";}}' > " + tmpfile, shell=True)
 
 	output = ""
 	with open(tmpfile) as f:


### PR DESCRIPTION
I basically add an option that allow user to switch to hmmsearch. Nothing change if the option is not specified.
In general, hmmsearch is doing exactly the same thing as hmmscan. There have been a lot of discussions (#27, #49 and #105) mentioning that hmmsearch is way faster than hmmscan when querying a lot of data (please also refer to [this thread](http://cryptogenomicon.org/hmmscan-vs-hmmsearch-speed-the-numerology.html)) and my recent issue #117 that the current code will cause too much burden on the cluster if several tasks are run parallelly. The differences are the e-value (which will be influenced by the sequence length) and the format. I take a look into the final overview.txt and found that we just need to slightly modify the order of the column extraction to get the identical results (except the e-value) processed from hmmsearch output.

### Code changes
run_dbcan.py
1. Add an option `--hmmsearch` to the `argparse` object to allow user to use hmmsearch instead of hmmscan.
2. Add the hmmsearch argument to the function `runHmmScan`, `split_uniInput` and `run`.
3. Modify the corresponding sections that run hmmscan with a if-else statement that determine which runner to use.
4. Add timer to hmmer and diamond. Would be great to know the processing time for all these core tools.

hmmscan_parser.py
1. Add the hmmsearch argument to the function `run`.
2. Add an if-else statement to switch the parsing codes to corresponding runner.

### Evaluation
I evaluated the changes in one of my data (prodigal results come from a metagenomic sample) and got 634 hits from the original [hmmscan version](https://github.com/linnabrown/run_dbcan/files/11568235/overview_hmmscan.txt) and 628 from the [hmmsearch version](https://github.com/linnabrown/run_dbcan/files/11568250/overview_hmmsearch.txt).  Among these hits, 48 are not identical but many of them are actually matching to the same target. (please refer to the [results_comparison.csv](https://github.com/linnabrown/run_dbcan/files/11568189/results_comparison.csv))

And there is a lot improvement in terms of the speed.
Since the previous version do not have timer for hmmer. I just compare the dbcan_sub module. To process 25320 sequences, the total time for the hmmscan version is 318683.97225904465 while the hmmsearch version is 3085.800838470459. It's around 100X faster.

### Caveat
I didn't go through the other submodule so maybe need further check whether they have any dependency on the function I made change of.